### PR TITLE
[Stream] Use pytorch's current cuda stream instead of default stream

### DIFF
--- a/fp6_llm/csrc/fp6_linear.cu
+++ b/fp6_llm/csrc/fp6_linear.cu
@@ -301,11 +301,16 @@ torch::Tensor fp_eXmY_linear_forward_cuda(
     options = torch::TensorOptions().dtype(torch::kFloat32).device(_in_feats.device());
     at::Tensor _workspace = torch::empty({splitK, num_in_feats, num_out_channels}, options);
     auto Reduction_Workspace = reinterpret_cast<float*>(_workspace.data_ptr<float>());  // Reduction_Workspace_Size = Split_K * M_Global * N_Global * sizeof(fp32)
+
+    // Get the current device and stream
+    int device_id = _in_feats.device().index();
+    auto stream = at::cuda::getCurrentCUDAStream(device_id).stream();
+
     //
     fp_eXmY_linear_kernel(
         EXPONENT,
         MANTISSA,
-        0, // Using default stream here.
+        stream, // Using torch's current stream here.
         weight,
         scales,
         in_feats,


### PR DESCRIPTION
Stream 0 (CUDA default stream) is hardcoded in the cpp implementation, which prevents the user to use other stream to launch the fp6-llm kernel. 

vLLM (and other frameworks that uses cuda graph) creates a custom stream to capture the kernels. The current implementation prevents vllm to capture the fp6-llm kernel. 

This PR changes the stream from CUDA default stream (0) to the torch current stream. 